### PR TITLE
Specify checkout steps to not iterate via confirm state

### DIFF
--- a/app/models/solidus_subscriptions/checkout.rb
+++ b/app/models/solidus_subscriptions/checkout.rb
@@ -76,7 +76,7 @@ module SolidusSubscriptions
       end
       apply_promotions
 
-      order.checkout_steps[0...-1].each do
+      %w[address delivery payment].each do
         order.ship_address = ship_address if order.state == "address"
         create_payment if order.state == "payment"
         order.next!


### PR DESCRIPTION
Currently checkout process fails with `Cannot transition state via :next from :confirm` error. 

This happens because `order.checkout_steps[0...-1]` returns `['address', 'delivery', 'payment', 'confirm']` and on **confirm** state it fails since order can't be transitioned to **complete** step by `#next!`. It should be transitioned by `#complete`, which happens later on line 87. 